### PR TITLE
Fix LED constant for PC13 blinking

### DIFF
--- a/blink.c
+++ b/blink.c
@@ -8,7 +8,7 @@
 #define GPIOC_ODR         (*(volatile unsigned int*)(GPIOC_BASE + 0x0C))
 
 #define RCC_IOPEN         (1 << 4)
-#define LED_PIN           (1 << 23)
+#define LED_PIN           (1 << 13)
 
 
 void delay(volatile unsigned int t){


### PR DESCRIPTION
## Summary
- correct GPIO pin number for PC13 in blink example

## Testing
- `make` *(fails: no makefile)*