### PR TITLE
Add Makefile and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+CC=arm-none-eabi-gcc
+CFLAGS=-Wall -mcpu=cortex-m3 -mthumb -nostdlib -ffreestanding
+LDFLAGS=-T link.ld -nostdlib
+
+all: blink.bin
+
+blink.o: blink.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+startup.o: startup.s
+	$(CC) $(CFLAGS) -c $< -o $@
+
+blink.elf: blink.o startup.o link.ld
+	$(CC) $(CFLAGS) blink.o startup.o $(LDFLAGS) -o $@
+
+blink.bin: blink.elf
+	arm-none-eabi-objcopy -O binary $< $@
+
+clean:
+	rm -f blink.o startup.o blink.elf blink.bin
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-A simple bare-metal program that blinks an LED on the STM32"blue-pill" 
+A simple bare-metal program that blinks an LED on the STM32 "blue-pill".
+
+Build instructions
+------------------
+This project requires the ARM GCC toolchain (`arm-none-eabi-gcc`).
+Run `make` to build the firmware. The output `blink.bin` can be flashed onto the board.


### PR DESCRIPTION
## Summary
- add Makefile for building the bare-metal example
- document build instructions in README

## Testing
- `make clean`
- `make` *(fails: arm-none-eabi-gcc not installed)*