### PR TITLE
Add run target to flash binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,8 @@ blink.bin: blink.elf
 clean:
 	rm -f blink.o startup.o blink.elf blink.bin
 
-.PHONY: all clean
+.PHONY: all clean run
+
+run: blink.bin
+	st-flash write blink.bin 0x8000000
+


### PR DESCRIPTION
## Summary
- add a `run` target that flashes `blink.bin` to the STM32 using `st-flash`
- include `run` in the list of phony targets

## Testing
- `make run` *(fails: arm-none-eabi-gcc missing)*