### PR TITLE
Add fixed loop for limited blinking

### DIFF
--- a/blink.c
+++ b/blink.c
@@ -23,7 +23,7 @@ int main(void){
   GPIO_CRH &= ~(0xF << 20);
   GPIO_CRH |= (0x2 << 20);
 
-  while(1){
+  for(int i = 0; i < 10; ++i){
     GPIOC_ODR &= ~LED_PIN;
     delay(1000);
     GPIOC_ODR |= LED_PIN;

--- a/startup.s
+++ b/startup.s
@@ -9,7 +9,8 @@
 
 .text
 _start:
-    bl main 
+    bl main
 
-loop:
-    b loop
+halt:
+    wfi
+    b halt


### PR DESCRIPTION
## Summary
- run the LED blink in a for-loop for ten cycles
- halt the CPU after `main` returns by waiting for interrupt

## Testing
- `make` *(fails: `arm-none-eabi-gcc: No such file or directory`)*